### PR TITLE
Switch from `prepublishOnly` to `prepare` in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "tsdx build",
     "start": "tsdx watch",
     "test": "tsdx test",
-    "prepublishOnly": "tsdx build"
+    "prepare": "tsdx build"
   },
   "dependencies": {
     "@ethersproject/address": "^5.0.0",


### PR DESCRIPTION
See if this allows you to properly add the Git repo to the package.json.